### PR TITLE
Handle New Account and WalletInfo Objects from Wallet

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@provenanceio/walletconnect-js",
-  "version": "0.2.0",
+  "version": "0.2.3",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "@provenanceio/walletconnect-js",
-      "version": "0.2.0",
+      "version": "0.2.3",
       "license": "Apache-2.0",
       "dependencies": {
         "@provenanceio/wallet-lib": "1.1.1",


### PR DESCRIPTION
<!-- < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < ☺
v                               ✰  Thanks for creating a PR! ✰
v    Before submitting, please review the checkboxes.
v    If a checkbox is n/a - please still include it but add a note why
☺ > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > >  -->

## Description

Currently, dApps and the wallets (mobile and web) use an array to communicate account information.  The wallet was updated to return an object like:

```
{
  "address": "tp1yrtcht90kvscc796adaj7vhr74295teqa6qsr2",
  "jwt": "eyJhbGciOiJFUzI1NksiLCJ0eXAiOiJKV1...snip",
  "publicKey": "A347cREn+NrvD+HVujC9+++mhmOCcLnWZwEmZRFEJS+p"
  "walletInfo": {
    "coin": "testNet",
    "id": "1",
    "name": "Test"
  }
}
```

This PR handles that new object and the wallet name.

---

Before we can merge this PR, please make sure that all the following items have been
checked off. If any of the checklist items are not applicable, please leave them but
write a little note why.

- [x] Targeted PR against correct branch
- [] Linked to Github issue with discussion and accepted design OR link to spec that describes this work.
- [ ] Added a relevant changelog entry to the `Unreleased` section in `CHANGELOG.md`
- [x] Re-reviewed `Files changed` in the Github PR explorer