### PR TITLE
Connection Timeout Resume

### DIFF
--- a/examples/example-react/package-lock.json
+++ b/examples/example-react/package-lock.json
@@ -96,7 +96,7 @@
     },
     "../@provenanceio-wcjs-local": {
       "name": "@provenanceio/walletconnect-js",
-      "version": "2.0.4",
+      "version": "2.0.5",
       "license": "Apache-2.0",
       "dependencies": {
         "@babel/runtime": "7.19.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@provenanceio/walletconnect-js",
-  "version": "2.0.5",
+  "version": "2.0.6",
   "private": false,
   "sideEffects": false,
   "main": "lib/index.js",

--- a/src/contexts/walletConnectContext.tsx
+++ b/src/contexts/walletConnectContext.tsx
@@ -19,12 +19,16 @@ const WalletConnectContextProvider: React.FC<Props> = ({ children }) => {
   const [walletConnectState, setWalletConnectState] = useState<WCSState>({
     ...walletConnectService.state,
   });
-  const { address } = walletConnectState;
+  const { address, connectionTimeout, bridge } = walletConnectState;
 
   useEffect(() => {
     walletConnectService.setStateUpdater(setWalletConnectState); // Whenever we change the react state, update the class state
     // Check if we have an address and public key, if so, auto-reconnect to session
-    if (address) walletConnectService.connect();
+    if (address) {
+      // ConnectionTimeout is saved in ms, the connect function takes it as seconds, so we need to convert
+      const duration = connectionTimeout / 1000;
+      walletConnectService.connect({ duration, bridge });
+    }
     // Only run this check if we arn't already connected
     else {
       // Check to see if resuming connection on a new domain (url params)

--- a/src/contexts/walletConnectContext.tsx
+++ b/src/contexts/walletConnectContext.tsx
@@ -26,7 +26,7 @@ const WalletConnectContextProvider: React.FC<Props> = ({ children }) => {
     // Check if we have an address and public key, if so, auto-reconnect to session
     if (address) {
       // ConnectionTimeout is saved in ms, the connect function takes it as seconds, so we need to convert
-      const duration = connectionTimeout / 1000;
+      const duration = connectionTimeout ? connectionTimeout / 1000 : undefined;
       walletConnectService.connect({ duration, bridge });
     }
     // Only run this check if we arn't already connected


### PR DESCRIPTION
<!-- < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < ☺
v                               ✰  Thanks for creating a PR! ✰
v    Before submitting, please review the checkboxes.
v    If a checkbox is n/a - please still include it but add a note why
☺ > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > >  -->

## Description
- When resuming a connection, context provider will reconnect pulling the connectionDuration from storage (vs using the default connection time)
- Version up
<!-- Add a description of the changes that this PR introduces and the files that
are the most critical to review.
-->

closes: #XXXX

---

Before we can merge this PR, please make sure that all the following items have been
checked off. If any of the checklist items are not applicable, please leave them but
write a little note why.

- [ ] Targeted PR against correct branch
- [ ] Linked to Github issue with discussion and accepted design OR link to spec that describes this work.
- [ ] Added a relevant changelog entry to the `Unreleased` section in `CHANGELOG.md`
- [ ] Re-reviewed `Files changed` in the Github PR explorer