### PR TITLE
Fix dynamic links

### DIFF
--- a/src/consts/dynamicLinkInfo.ts
+++ b/src/consts/dynamicLinkInfo.ts
@@ -30,7 +30,7 @@ export const DYNAMIC_LINK_INFO_TEST_PROVENANCE = {
 
 export const DYNAMIC_LINK_INFO_PROD_FIGURE = {
   domainUriPrefix: 'https://figurewallet.page.link',
-  link: `https://figure.com/wallet-connect?data=$encodedWalletConnectData`,
+  link: `https://figure.com/wallet-connect`,
   androidInfo: {
     androidPackageName: 'com.figure.mobile.wallet',
   },
@@ -45,7 +45,7 @@ export const DYNAMIC_LINK_INFO_PROD_FIGURE = {
 
 export const DYNAMIC_LINK_INFO_TEST_FIGURE = {
   domainUriPrefix: 'https://figurewallet.page.link',
-  link: `https://figure.com/wallet-connect?data=$encodedWalletConnectData`,
+  link: `https://figure.com/wallet-connect`,
   androidInfo: {
     androidPackageName: 'com.figure.mobile.wallet.dev',
   },


### PR DESCRIPTION
The current Figure Mobile dynamic links redirect to something like
```
https://figure.com/wallet-connect?data=$encodedWalletConnectData?data%3Dwc:850461b8-1643-4e91-9c55-32d894359154@1?bridge%3Dwss://test.figure.tech/service-wallet-connect-bridge/ws/external%26key%3Dd67db6fcb4848e033a34b16e54d53b9e2e3f44fa6278de235418a340c943c162
```
with an errant data param `?data=$encodedWalletConnectData`