### PR TITLE
Require Hex Msg For Signature Verification

### DIFF
--- a/examples/example-react-vite/package-lock.json
+++ b/examples/example-react-vite/package-lock.json
@@ -856,7 +856,7 @@
     "node_modules/@provenanceio/walletconnect-js": {
       "version": "3.0.0-develop.13",
       "resolved": "file:../provenanceio-walletconnect-js-3.0.0-develop.13.tgz",
-      "integrity": "sha512-49zAVsmplGs7TFSD4sHXXjabFaCPScsiQ82fULz7Zbw+kzPr8jMRAsV9jFG4hZaIH25ZJLk9lGHHmzN4DUoogg==",
+      "integrity": "sha512-VXs3Mc/9bJFO7YJgZjAViNWFd/2tWgVNaFZFFltw7Wmyr2uw1jlmx0Hc6VgbKA9Ltv/C1Ve3GYw6HXr022jpag==",
       "license": "Apache-2.0",
       "dependencies": {
         "@babel/runtime": "7.19.0",
@@ -4469,7 +4469,7 @@
     },
     "@provenanceio/walletconnect-js": {
       "version": "file:../provenanceio-walletconnect-js-3.0.0-develop.13.tgz",
-      "integrity": "sha512-49zAVsmplGs7TFSD4sHXXjabFaCPScsiQ82fULz7Zbw+kzPr8jMRAsV9jFG4hZaIH25ZJLk9lGHHmzN4DUoogg==",
+      "integrity": "sha512-VXs3Mc/9bJFO7YJgZjAViNWFd/2tWgVNaFZFFltw7Wmyr2uw1jlmx0Hc6VgbKA9Ltv/C1Ve3GYw6HXr022jpag==",
       "requires": {
         "@babel/runtime": "7.19.0",
         "@walletconnect/client": "1.8.0",

--- a/examples/example-react-vite/package-lock.json
+++ b/examples/example-react-vite/package-lock.json
@@ -1,16 +1,16 @@
 {
   "name": "example-react-vite",
-  "version": "3.0.0-develop.13",
+  "version": "3.0.0-develop.14",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "example-react-vite",
-      "version": "3.0.0-develop.13",
+      "version": "3.0.0-develop.14",
       "dependencies": {
         "@microlink/react-json-view": "1.22.2",
         "@provenanceio/wallet-utils": "2.4.1",
-        "@provenanceio/walletconnect-js": "file:../provenanceio-walletconnect-js-3.0.0-develop.13.tgz",
+        "@provenanceio/walletconnect-js": "file:../provenanceio-walletconnect-js-3.0.0-develop.14.tgz",
         "react": "^18.2.0",
         "react-dom": "^18.2.0",
         "react-helmet-async": "1.3.0",
@@ -854,9 +854,9 @@
       }
     },
     "node_modules/@provenanceio/walletconnect-js": {
-      "version": "3.0.0-develop.13",
-      "resolved": "file:../provenanceio-walletconnect-js-3.0.0-develop.13.tgz",
-      "integrity": "sha512-VXs3Mc/9bJFO7YJgZjAViNWFd/2tWgVNaFZFFltw7Wmyr2uw1jlmx0Hc6VgbKA9Ltv/C1Ve3GYw6HXr022jpag==",
+      "version": "3.0.0-develop.14",
+      "resolved": "file:../provenanceio-walletconnect-js-3.0.0-develop.14.tgz",
+      "integrity": "sha512-sb8SxYiFxLP9JXllrORuIABdkVKHWYggS2fBjvqN05MXudAIGAR2d0sUV9xNleF01lh9r3z3c5/rR360qI3GSA==",
       "license": "Apache-2.0",
       "dependencies": {
         "@babel/runtime": "7.19.0",
@@ -4468,8 +4468,8 @@
       }
     },
     "@provenanceio/walletconnect-js": {
-      "version": "file:../provenanceio-walletconnect-js-3.0.0-develop.13.tgz",
-      "integrity": "sha512-VXs3Mc/9bJFO7YJgZjAViNWFd/2tWgVNaFZFFltw7Wmyr2uw1jlmx0Hc6VgbKA9Ltv/C1Ve3GYw6HXr022jpag==",
+      "version": "file:../provenanceio-walletconnect-js-3.0.0-develop.14.tgz",
+      "integrity": "sha512-sb8SxYiFxLP9JXllrORuIABdkVKHWYggS2fBjvqN05MXudAIGAR2d0sUV9xNleF01lh9r3z3c5/rR360qI3GSA==",
       "requires": {
         "@babel/runtime": "7.19.0",
         "@walletconnect/client": "1.8.0",

--- a/examples/example-react-vite/package.json
+++ b/examples/example-react-vite/package.json
@@ -1,7 +1,7 @@
 {
   "name": "example-react-vite",
   "private": true,
-  "version": "3.0.0-develop.13",
+  "version": "3.0.0-develop.14",
   "homepage": "/walletconnect-demo",
   "type": "module",
   "scripts": {
@@ -16,7 +16,7 @@
   "dependencies": {
     "@microlink/react-json-view": "1.22.2",
     "@provenanceio/wallet-utils": "2.4.1",
-    "@provenanceio/walletconnect-js": "file:../provenanceio-walletconnect-js-3.0.0-develop.13.tgz",
+    "@provenanceio/walletconnect-js": "file:../provenanceio-walletconnect-js-3.0.0-develop.14.tgz",
     "react": "^18.2.0",
     "react-dom": "^18.2.0",
     "react-helmet-async": "1.3.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@provenanceio/walletconnect-js",
-  "version": "3.0.0-develop.13",
+  "version": "3.0.0-develop.14",
   "private": false,
   "sideEffects": false,
   "main": "lib/index.js",

--- a/src/__tests__/unit/hex-sign.test.ts
+++ b/src/__tests__/unit/hex-sign.test.ts
@@ -1,0 +1,53 @@
+import {isHex, sha256, verifySignature} from "../../helpers";
+import {ecdsaVerify} from "secp256k1";
+import base64url from "base64url";
+import {createHash} from "crypto";
+import {convertUtf8ToHex} from "@walletconnect/utils";
+
+describe(`test signing`, () => {
+    it('is hex', () => {
+        expect(isHex("0xdeadbeef")).toBe(false);
+        expect(isHex("deadbeef")).toBe(true);
+        expect(isHex("0123456789abcDEF")).toBe(true);
+        expect(isHex("0123456789abcDEFg")).toBe(false);
+        expect(isHex("")).toBe(false);
+        expect(isHex("0")).toBe(true);
+
+    })
+    it(`should verify unprintable characters signature`, async () => {
+        const hexMessage = 'deadbeef';
+        const hexMessageBytes = Buffer.from(hexMessage, 'hex');
+        const hexMessageHash = createHash('sha256').update(hexMessageBytes).digest();
+
+        const pubkB64 = 'AhwcM7CrTH0iBc2pnhCltUJwpoRufulPUu6yv88w6Qh1';
+        const pubkBytes = base64url.toBuffer(pubkB64);
+
+        const signature = 'a74c498f2de8f2820f975570248f33d2b72521b6b03f0fd721419f0c020f8b9a481ba48c55d38ff70beec306d21506c5a165401d5cc36d5aec3f5c281ec1bdf0';
+        const signatureBytes = Buffer.from(signature, 'hex');
+
+
+        const ecdsaVerifyResult = ecdsaVerify(signatureBytes, hexMessageHash, pubkBytes);
+        const wcVerifyResult = await verifySignature(hexMessage, signatureBytes, pubkB64);
+
+        expect(ecdsaVerifyResult).toBe(true);
+        expect(ecdsaVerifyResult).toBe(wcVerifyResult);
+    }),
+    it(`should verify jwt signature`, async () => {
+        const jwt = 'eyJhbGciOiJFUzI1NksiLCJ0eXAiOiJKV1QifQ.eyJzdWIiOiJBaHdjTTdDclRIMGlCYzJwbmhDbHRVSndwb1J1ZnVsUFV1Nnl2ODh3NlFoMSIsImlzcyI6InByb3ZlbmFuY2UuaW8iLCJpYXQiOjE2Nzc1Mjc2NTksImV4cCI6MTY3NzUyODI1OSwiYWRkciI6InRwMTNka2g2bGhlNXp6ZmU0cXdrbDRmcXlmbWg1OHAzNXc1cWF4d3h5In0';
+        const jwtHex = convertUtf8ToHex(jwt, true);
+        const hexMessageBytes = Buffer.from(jwtHex, 'hex');
+        const hexMessageHash = createHash('sha256').update(hexMessageBytes).digest();
+
+        const pubkB64 = 'AhwcM7CrTH0iBc2pnhCltUJwpoRufulPUu6yv88w6Qh1';
+        const pubkBytes = base64url.toBuffer(pubkB64);
+
+        const signature = '8a2ed625c1c290317b98c653cc166249056010662fedac850c904e1ecf3b718b4c3dbd4e1fe986b62d7ccb31a6e152140442fa02d2a7ee40e6218ca31ee4d307';
+        const signatureBytes = Buffer.from(signature, 'hex');
+
+        const ecdsaVerifyResult = ecdsaVerify(signatureBytes, hexMessageHash, pubkBytes);
+        const wcVerifyResult = await verifySignature(jwtHex, signatureBytes, pubkB64);
+
+        expect(ecdsaVerifyResult).toBe(true);
+        expect(ecdsaVerifyResult).toBe(wcVerifyResult);
+    })
+})

--- a/src/helpers/helpers.ts
+++ b/src/helpers/helpers.ts
@@ -1,14 +1,16 @@
 import base64url from 'base64url';
-import { createHash } from 'crypto';
-import { ecdsaVerify } from 'secp256k1';
+import {createHash} from 'crypto';
+import {ecdsaVerify} from 'secp256k1';
 
-export const sha256 = (message: string) => createHash('sha256').update(Buffer.from(message,"utf-8")).digest();
+export const sha256 = (hexMessage: string) => createHash('sha256').update(Buffer.from(hexMessage, 'hex')).digest();
+export const isHex = (hexMessage: string) => !!hexMessage.match("^[0-9a-fA-F]+$")
 
 export const verifySignature = async (
-  message: string, signature: Uint8Array, pubKeyB64: string,
+    hexMessage: string, signature: Uint8Array, pubKeyB64: string,
 ) => {
-  const hash = sha256(message);
-  const pubKeyDecoded = base64url.toBuffer(pubKeyB64);
+    if (!isHex(hexMessage)) throw new Error("Message parameter is not a hex value.");
 
-  return ecdsaVerify(signature, hash, pubKeyDecoded)
+    const hash = sha256(hexMessage);
+    const pubKeyDecoded = base64url.toBuffer(pubKeyB64);
+    return ecdsaVerify(signature, hash, pubKeyDecoded);
 };

--- a/src/services/methods/signHexMessage.ts
+++ b/src/services/methods/signHexMessage.ts
@@ -52,10 +52,8 @@ export const signHexMessage = async ({
     const result = (await connector.sendCustomRequest(request)) as string;
     // result is a hex encoded signature
     const signature = Uint8Array.from(Buffer.from(result, 'hex'));
-    // un-hex the message to verify the signature (the wallet signs the un-hexed message)
-    const message = Buffer.from(hexMessage, 'hex').toString();
     // verify signature
-    valid = await verifySignature(message, signature, pubKeyB64);
+    valid = await verifySignature(hexMessage, signature, pubKeyB64);
     return { valid, result, data: hexMessage, request };
   } catch (error) {
     return { valid, error: `${error}`, data: hexMessage, request };

--- a/src/services/methods/signJWT.ts
+++ b/src/services/methods/signJWT.ts
@@ -70,7 +70,7 @@ export const signJWT = async ({
   const payloadEncoded = base64url(payload);
   const JWT = `${headerEncoded}.${payloadEncoded}`;
 
-  const hexJWT = convertUtf8ToHex(JWT);
+  const hexJWT = convertUtf8ToHex(JWT, true);
   request.params.push(hexJWT);
 
   try {
@@ -85,7 +85,7 @@ export const signJWT = async ({
     // const signature = Uint8Array.from(Buffer.from(result, 'hex'));
     const signature = Buffer.from(result, 'hex');
     // verify signature
-    valid = await verifySignature(JWT, signature, pubKeyB64);
+    valid = await verifySignature(hexJWT, signature, pubKeyB64);
     const signedPayloadEncoded = base64url(signature);
     const signedJWT = `${headerEncoded}.${payloadEncoded}.${signedPayloadEncoded}`;
     // Update JWT within the wcjs state


### PR DESCRIPTION
## Description

When verifying non-printable hex-encode message, signature verification would fail. Change `verifySignature` to require and enforce hex-encode messages only. 

---

Before we can merge this PR, please make sure that all the following items have been
checked off. If any of the checklist items are not applicable, please leave them but
write a little note why.

- [x] Targeted PR against correct branch
- [x] Linked to Github issue with discussion and accepted design OR link to spec that describes this work.
- [x] Added a relevant changelog entry to the `Unreleased` section in `CHANGELOG.md`
- [x] Re-reviewed `Files changed` in the Github PR explorer