### PR TITLE
add onQRCodeSet callback for code creation reactivity

### DIFF
--- a/examples/example-react-vite/package-lock.json
+++ b/examples/example-react-vite/package-lock.json
@@ -1,16 +1,16 @@
 {
   "name": "example-react-vite",
-  "version": "3.0.0-develop.16",
+  "version": "3.0.0-develop.17",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "example-react-vite",
-      "version": "3.0.0-develop.16",
+      "version": "3.0.0-develop.17",
       "dependencies": {
         "@microlink/react-json-view": "1.22.2",
         "@provenanceio/wallet-utils": "2.8.0",
-        "@provenanceio/walletconnect-js": "file:../provenanceio-walletconnect-js-3.0.0-develop.16.tgz",
+        "@provenanceio/walletconnect-js": "file:../provenanceio-walletconnect-js-3.0.0-develop.17.tgz",
         "react": "^18.2.0",
         "react-dom": "^18.2.0",
         "react-helmet-async": "1.3.0",
@@ -854,9 +854,9 @@
       }
     },
     "node_modules/@provenanceio/walletconnect-js": {
-      "version": "3.0.0-develop.16",
-      "resolved": "file:../provenanceio-walletconnect-js-3.0.0-develop.16.tgz",
-      "integrity": "sha512-WqGCQY6QfVTrRtfCn0xtJcVlvpSWqZQDNxi4P6JkiyLYchvnJvnHr4FdRZaBdUPPYc8zXEaR3qDb8KQpz8DADA==",
+      "version": "3.0.0-develop.17",
+      "resolved": "file:../provenanceio-walletconnect-js-3.0.0-develop.17.tgz",
+      "integrity": "sha512-18FjNBvLHfxGaghNUba+fyBDsvXtuyuqmoE7mdn/7sycM0cmgRRzaTtl5X6h6+bdWrpGCuRptezo8Msf2072ng==",
       "license": "Apache-2.0",
       "dependencies": {
         "@babel/runtime": "7.19.0",
@@ -4468,8 +4468,8 @@
       }
     },
     "@provenanceio/walletconnect-js": {
-      "version": "file:../provenanceio-walletconnect-js-3.0.0-develop.16.tgz",
-      "integrity": "sha512-WqGCQY6QfVTrRtfCn0xtJcVlvpSWqZQDNxi4P6JkiyLYchvnJvnHr4FdRZaBdUPPYc8zXEaR3qDb8KQpz8DADA==",
+      "version": "file:../provenanceio-walletconnect-js-3.0.0-develop.17.tgz",
+      "integrity": "sha512-18FjNBvLHfxGaghNUba+fyBDsvXtuyuqmoE7mdn/7sycM0cmgRRzaTtl5X6h6+bdWrpGCuRptezo8Msf2072ng==",
       "requires": {
         "@babel/runtime": "7.19.0",
         "@walletconnect/client": "1.8.0",

--- a/examples/example-react-vite/src/Page/Connect.tsx
+++ b/examples/example-react-vite/src/Page/Connect.tsx
@@ -142,6 +142,7 @@ export const Connect: React.FC = () => {
               groupAddress,
               prohibitGroups: !groupsAllowed,
               jwtExpiration: Number(jwtExpiration),
+              onQRCodeSet: console.log
             })
           }
         >

--- a/examples/example-react-vite/vite.config.ts
+++ b/examples/example-react-vite/vite.config.ts
@@ -10,4 +10,9 @@ export default defineConfig({
   define: {
     APP_VERSION: JSON.stringify(process.env.npm_package_version),
   },
+  resolve: {
+    alias: {
+      '@provenanceio/walletconnect-js': __dirname + '/../../src/index.ts',
+    },
+  },
 });

--- a/src/services/methods/connect/connect.ts
+++ b/src/services/methods/connect/connect.ts
@@ -1,21 +1,4 @@
-import { createConnector } from './createConnector';
-import type { Broadcast, WCSState, WCSSetState, ModalData } from '../../../types';
-
-interface Props {
-  bridge: string;
-  broadcast: Broadcast;
-  getState: () => WCSState;
-  jwtExpiration?: number;
-  noPopup?: boolean;
-  prohibitGroups?: boolean;
-  requiredIndividualAddress?: string;
-  requiredGroupAddress?: string;
-  resetState: () => void;
-  setState: WCSSetState;
-  startConnectionTimer: () => void;
-  state: WCSState;
-  updateModal: (newModalData: Partial<ModalData>) => void;
-}
+import { createConnector, type ConnectOptions } from './createConnector';
 
 // This connect method has three parts:
 // Creating a new connector w/connector.on() events (connect, session_update, and disconnect)
@@ -35,7 +18,8 @@ export const connect = ({
   startConnectionTimer,
   state,
   updateModal,
-}: Props) => {
+  onQRCodeSet,
+}: ConnectOptions) => {
   // Create a new walletconnect connector class and set up all walletconnect event listeners for it
   const newConnector = createConnector({
     bridge,
@@ -51,6 +35,7 @@ export const connect = ({
     state,
     startConnectionTimer,
     updateModal,
+    onQRCodeSet,
   });
 
   // If we're not connected, initiate a connection to this newConnector and dApp

--- a/src/services/methods/connect/createConnector.ts
+++ b/src/services/methods/connect/createConnector.ts
@@ -15,7 +15,7 @@ import {
 } from '../../../consts';
 import { getAccountInfo, sendWalletEvent } from '../../../utils';
 
-interface Props {
+export interface ConnectOptions {
   bridge: string;
   broadcast: Broadcast;
   getState: () => WCSState;
@@ -29,6 +29,7 @@ interface Props {
   startConnectionTimer: () => void;
   state: WCSState;
   updateModal: (newModalData: Partial<ModalData>) => void;
+  onQRCodeSet?: (qrCode: { img: string; url: string }) => void;
 }
 
 export const createConnector = ({
@@ -45,7 +46,8 @@ export const createConnector = ({
   startConnectionTimer,
   state,
   updateModal,
-}: Props) => {
+  onQRCodeSet,
+}: ConnectOptions) => {
   class QRCodeModal {
     open = async (data: string) => {
       // Check for address and prohibit groups values to append to the wc value for the wallet to read when connecting
@@ -62,6 +64,7 @@ export const createConnector = ({
       const fullData = `${data}${requiredIndividualAddressParam}${requiredGroupAddressParam}${prohibitGroupsParam}${jwtExpirationParam}`;
       const qrcode = await QRCode.toDataURL(fullData);
       updateModal({ QRCodeImg: qrcode, QRCodeUrl: fullData, showModal: !noPopup });
+      onQRCodeSet?.({ img: qrcode, url: fullData });
     };
 
     close = () => {

--- a/src/services/walletConnectService.ts
+++ b/src/services/walletConnectService.ts
@@ -427,6 +427,7 @@ export class WalletConnectService {
    * @param groupAddress - (optional) Group address to establish connection with, note, if requested, it must exist
    * @param prohibitGroups - (optional) Does this dApp ban group accounts connecting to it
    * @param jwtExpiration - (optional) Time from now in seconds to expire new JWT returned
+   * @param onQRCodeSet - (optional) Callback to be fired with the QRCode data once set
    */
   connect = ({
     individualAddress,
@@ -436,6 +437,7 @@ export class WalletConnectService {
     jwtExpiration,
     noPopup,
     prohibitGroups,
+    onQRCodeSet,
   }: ConnectMethod = {}) => {
     // Only create a new connector when we're not already connected
     if (this.state.status !== 'connected') {
@@ -458,6 +460,7 @@ export class WalletConnectService {
         startConnectionTimer: this.#startConnectionTimer,
         state: this.state,
         updateModal: this.updateModal,
+        onQRCodeSet,
       });
 
       this.#connector = newConnector;

--- a/src/types/WalletConnectService.ts
+++ b/src/types/WalletConnectService.ts
@@ -84,6 +84,7 @@ export interface ConnectMethod {
   groupAddress?: string;
   prohibitGroups?: boolean;
   jwtExpiration?: number;
+  onQRCodeSet?: (qrCode: { img: string; url: string }) => void;
 }
 
 export interface SendMessageMethod {


### PR DESCRIPTION
<!-- < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < ☺
v                               ✰  Thanks for creating a PR! ✰
v    Before submitting, please review the checkboxes.
v    If a checkbox is n/a - please still include it but add a note why
☺ > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > >  -->

## Description

For custom QRCode behaviors, it's important to react to the creation/setting of the image and URL. This PR adds a callback to the connect options so the calling code can wait on it for action. For example, the following code needs to wait on the QRCode to launch the extension, but the amount of time is arbitrary and subject to break depending on the creation time:
https://github.com/FigureTechnologies/frontend/pull/79/files#diff-021f6904352b012eee7fc85cff80d504f11ff0061a4735cf257135ce5d538bc9R37

This also adds aliasing to the Vite example for instant reloading while developing the library.

---

Before we can merge this PR, please make sure that all the following items have been
checked off. If any of the checklist items are not applicable, please leave them but
write a little note why.

- [x] Targeted PR against correct branch
- [x] Linked to Github issue with discussion and accepted design OR link to spec that describes this work.
- [ ] Added a relevant changelog entry to the `Unreleased` section in `CHANGELOG.md` - file missing
- [x] Re-reviewed `Files changed` in the Github PR explorer