### PR TITLE
fix: prevent multiple popups (for hosted wallet)

### DIFF
--- a/examples/example-react-vite/package.json
+++ b/examples/example-react-vite/package.json
@@ -1,7 +1,7 @@
 {
   "name": "example-react-vite",
   "private": true,
-  "version": "3.0.2",
+  "version": "3.0.3",
   "homepage": "/walletconnect-demo",
   "type": "module",
   "scripts": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@provenanceio/walletconnect-js",
-  "version": "3.0.2",
+  "version": "3.0.3",
   "private": false,
   "sideEffects": false,
   "main": "esm/index.js",

--- a/src/consts/walletList/hosted.ts
+++ b/src/consts/walletList/hosted.ts
@@ -34,7 +34,7 @@ export const FIGURE_HOSTED = {
       const top = window.outerHeight / 2 + window.screenY - height / 2;
       const left = window.outerWidth / 2 + window.screenX - width / 2;
       const windowOptions = `popup=1 height=${height} width=${width} top=${top} left=${left} resizable=1, scrollbars=1, fullscreen=0, toolbar=0, menubar=0, status=1`;
-      window.open(url, undefined, windowOptions);
+      window.open(url, 'figure-wallet-hosted', windowOptions);
     }
   },
 } as Wallet;
@@ -63,7 +63,7 @@ export const FIGURE_HOSTED_TEST = {
       const top = window.outerHeight / 2 + window.screenY - height / 2;
       const left = window.outerWidth / 2 + window.screenX - width / 2;
       const windowOptions = `popup=1 height=${height} width=${width} top=${top} left=${left} resizable=1, scrollbars=1, fullscreen=0, toolbar=0, menubar=0, status=1`;
-      window.open(url, undefined, windowOptions);
+      window.open(url, 'figure-wallet-hosted-test', windowOptions);
     }
   },
 } as Wallet;


### PR DESCRIPTION
## Description

This changes the behavior when opening the Figure Hosted Wallet wallet type. Previously, `window.open` was called with an `undefined` target which would popup a new window for each invocation. This caused some confusion and poor UX as it was easy to have several popup windows (in various states) in the background unknowingly. With this change, the same window is used/reused for Figure Hosted Wallet.