### PR TITLE
fix: allow for hosted (test) url override [sc-229571]

### DIFF
--- a/examples/example-react-vite/package-lock.json
+++ b/examples/example-react-vite/package-lock.json
@@ -1018,7 +1018,7 @@
     "node_modules/@provenanceio/walletconnect-js": {
       "version": "3.0.5",
       "resolved": "file:../provenanceio-walletconnect-js-3.0.5.tgz",
-      "integrity": "sha512-8OZ5KHBbw+Xm5DCQZX2MGZXfN72Jjml4jPZOWgIOdOq9nuPmiZzEI/AWZywQDg4qX4PDYjj7q4oa4rzgwOFa/g==",
+      "integrity": "sha512-yAx0x1zambMOgbsUOpEU/weNNgfoGJdEW7TmYUlJkewIV6t0M8q47vkDeLXJkCiJ/14sAF2xEcn+myEGmV47xw==",
       "license": "Apache-2.0",
       "dependencies": {
         "@babel/runtime": "7.19.0",
@@ -7238,7 +7238,7 @@
     },
     "@provenanceio/walletconnect-js": {
       "version": "file:../provenanceio-walletconnect-js-3.0.5.tgz",
-      "integrity": "sha512-8OZ5KHBbw+Xm5DCQZX2MGZXfN72Jjml4jPZOWgIOdOq9nuPmiZzEI/AWZywQDg4qX4PDYjj7q4oa4rzgwOFa/g==",
+      "integrity": "sha512-yAx0x1zambMOgbsUOpEU/weNNgfoGJdEW7TmYUlJkewIV6t0M8q47vkDeLXJkCiJ/14sAF2xEcn+myEGmV47xw==",
       "requires": {
         "@babel/runtime": "7.19.0",
         "@walletconnect/client": "1.8.0",

--- a/examples/example-react-vite/package-lock.json
+++ b/examples/example-react-vite/package-lock.json
@@ -10,7 +10,7 @@
       "dependencies": {
         "@microlink/react-json-view": "1.22.2",
         "@provenanceio/wallet-utils": "2.8.0",
-        "@provenanceio/walletconnect-js": "file:../provenanceio-walletconnect-js-3.0.4.tgz",
+        "@provenanceio/walletconnect-js": "file:../provenanceio-walletconnect-js-3.0.5.tgz",
         "react": "^18.2.0",
         "react-dom": "^18.2.0",
         "react-helmet-async": "1.3.0",
@@ -1016,9 +1016,9 @@
       }
     },
     "node_modules/@provenanceio/walletconnect-js": {
-      "version": "3.0.4",
-      "resolved": "file:../provenanceio-walletconnect-js-3.0.4.tgz",
-      "integrity": "sha512-PXRHDiq/T0Gn4TvbRP4M2TtE9jVzPwc9vBH8J/kgXjg87RJO/ew+VFVWvEkr97Xve4J3SUFEe4penJk8ql/ptw==",
+      "version": "3.0.5",
+      "resolved": "file:../provenanceio-walletconnect-js-3.0.5.tgz",
+      "integrity": "sha512-8OZ5KHBbw+Xm5DCQZX2MGZXfN72Jjml4jPZOWgIOdOq9nuPmiZzEI/AWZywQDg4qX4PDYjj7q4oa4rzgwOFa/g==",
       "license": "Apache-2.0",
       "dependencies": {
         "@babel/runtime": "7.19.0",
@@ -7237,8 +7237,8 @@
       }
     },
     "@provenanceio/walletconnect-js": {
-      "version": "file:../provenanceio-walletconnect-js-3.0.4.tgz",
-      "integrity": "sha512-PXRHDiq/T0Gn4TvbRP4M2TtE9jVzPwc9vBH8J/kgXjg87RJO/ew+VFVWvEkr97Xve4J3SUFEe4penJk8ql/ptw==",
+      "version": "file:../provenanceio-walletconnect-js-3.0.5.tgz",
+      "integrity": "sha512-8OZ5KHBbw+Xm5DCQZX2MGZXfN72Jjml4jPZOWgIOdOq9nuPmiZzEI/AWZywQDg4qX4PDYjj7q4oa4rzgwOFa/g==",
       "requires": {
         "@babel/runtime": "7.19.0",
         "@walletconnect/client": "1.8.0",

--- a/examples/example-react-vite/package-lock.json
+++ b/examples/example-react-vite/package-lock.json
@@ -1,16 +1,16 @@
 {
   "name": "example-react-vite",
-  "version": "3.0.4",
+  "version": "3.0.5",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "example-react-vite",
-      "version": "3.0.4",
+      "version": "3.0.5",
       "dependencies": {
         "@microlink/react-json-view": "1.22.2",
         "@provenanceio/wallet-utils": "2.8.0",
-        "@provenanceio/walletconnect-js": "file:../provenanceio-walletconnect-js-3.0.2-develop.1.tgz",
+        "@provenanceio/walletconnect-js": "file:../provenanceio-walletconnect-js-3.0.4.tgz",
         "react": "^18.2.0",
         "react-dom": "^18.2.0",
         "react-helmet-async": "1.3.0",
@@ -1016,9 +1016,9 @@
       }
     },
     "node_modules/@provenanceio/walletconnect-js": {
-      "version": "3.0.2-develop.1",
-      "resolved": "file:../provenanceio-walletconnect-js-3.0.2-develop.1.tgz",
-      "integrity": "sha512-1t4NqmkAHSOphJIj2zg6vYYfwPNtlBIE5jQq0zTO8vfFdscsdj7AnaW7C6ZEukX8Y9d/twJgUbHeJF/TKlCuDQ==",
+      "version": "3.0.4",
+      "resolved": "file:../provenanceio-walletconnect-js-3.0.4.tgz",
+      "integrity": "sha512-PXRHDiq/T0Gn4TvbRP4M2TtE9jVzPwc9vBH8J/kgXjg87RJO/ew+VFVWvEkr97Xve4J3SUFEe4penJk8ql/ptw==",
       "license": "Apache-2.0",
       "dependencies": {
         "@babel/runtime": "7.19.0",
@@ -7237,8 +7237,8 @@
       }
     },
     "@provenanceio/walletconnect-js": {
-      "version": "file:../provenanceio-walletconnect-js-3.0.2-develop.1.tgz",
-      "integrity": "sha512-1t4NqmkAHSOphJIj2zg6vYYfwPNtlBIE5jQq0zTO8vfFdscsdj7AnaW7C6ZEukX8Y9d/twJgUbHeJF/TKlCuDQ==",
+      "version": "file:../provenanceio-walletconnect-js-3.0.4.tgz",
+      "integrity": "sha512-PXRHDiq/T0Gn4TvbRP4M2TtE9jVzPwc9vBH8J/kgXjg87RJO/ew+VFVWvEkr97Xve4J3SUFEe4penJk8ql/ptw==",
       "requires": {
         "@babel/runtime": "7.19.0",
         "@walletconnect/client": "1.8.0",

--- a/examples/example-react-vite/package.json
+++ b/examples/example-react-vite/package.json
@@ -1,7 +1,7 @@
 {
   "name": "example-react-vite",
   "private": true,
-  "version": "3.0.4",
+  "version": "3.0.5",
   "homepage": "/walletconnect-demo",
   "type": "module",
   "scripts": {
@@ -16,7 +16,7 @@
   "dependencies": {
     "@microlink/react-json-view": "1.22.2",
     "@provenanceio/wallet-utils": "2.8.0",
-    "@provenanceio/walletconnect-js": "file:../provenanceio-walletconnect-js-3.0.2.tgz",
+    "@provenanceio/walletconnect-js": "file:../provenanceio-walletconnect-js-3.0.4.tgz",
     "react": "^18.2.0",
     "react-dom": "^18.2.0",
     "react-helmet-async": "1.3.0",

--- a/examples/example-react-vite/package.json
+++ b/examples/example-react-vite/package.json
@@ -16,7 +16,7 @@
   "dependencies": {
     "@microlink/react-json-view": "1.22.2",
     "@provenanceio/wallet-utils": "2.8.0",
-    "@provenanceio/walletconnect-js": "file:../provenanceio-walletconnect-js-3.0.4.tgz",
+    "@provenanceio/walletconnect-js": "file:../provenanceio-walletconnect-js-3.0.5.tgz",
     "react": "^18.2.0",
     "react-dom": "^18.2.0",
     "react-helmet-async": "1.3.0",

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@provenanceio/walletconnect-js",
-  "version": "3.0.4",
+  "version": "3.0.5",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "@provenanceio/walletconnect-js",
-      "version": "3.0.4",
+      "version": "3.0.5",
       "license": "Apache-2.0",
       "dependencies": {
         "@babel/runtime": "7.19.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@provenanceio/walletconnect-js",
-  "version": "3.0.4",
+  "version": "3.0.5",
   "private": false,
   "sideEffects": false,
   "main": "esm/index.js",
@@ -100,7 +100,7 @@
     "build:commonjs": "BABEL_ENV=cjs babel ./src --extensions \".js,.jsx,.ts,.tsx\" -d lib --copy-files",
     "build:esm": "BABEL_ENV=esm babel src -d esm --extensions \".js,.jsx,.ts,.tsx\" --copy-files",
     "build:umd": "webpack",
-    "build:pack": "npm run clean && npm run build:commonjs && npm run tsc:commonjs && npm pack --pack-destination './examples'",
+    "build:pack": "npm run clean && npm run build:commonjs && npm run build:esm && npm run tsc:commonjs && npm pack --pack-destination './examples'",
     "build": "npm run clean && npm run build:commonjs && npm run build:esm && npm run build:umd && npm run tsc:esm && npm run tsc:commonjs",
     "clean": "rm -rf ./lib ./esm ./umd ./examples/provenanceio-walletconnect-js-*.tgz",
     "commentSniff": "node -e 'require(\"./scripts/commentSniffer.js\").commentSniffer()'",

--- a/package.json
+++ b/package.json
@@ -100,7 +100,7 @@
     "build:commonjs": "BABEL_ENV=cjs babel ./src --extensions \".js,.jsx,.ts,.tsx\" -d lib --copy-files",
     "build:esm": "BABEL_ENV=esm babel src -d esm --extensions \".js,.jsx,.ts,.tsx\" --copy-files",
     "build:umd": "webpack",
-    "build:pack": "npm run clean && npm run build:commonjs && npm run build:esm && npm run tsc:commonjs && npm run tsc:esm && npm pack --pack-destination './examples'",
+    "build:pack": "npm run clean && npm run build:esm && npm run tsc:esm && npm pack --pack-destination './examples'",
     "build": "npm run clean && npm run build:commonjs && npm run build:esm && npm run build:umd && npm run tsc:esm && npm run tsc:commonjs",
     "clean": "rm -rf ./lib ./esm ./umd ./examples/provenanceio-walletconnect-js-*.tgz",
     "commentSniff": "node -e 'require(\"./scripts/commentSniffer.js\").commentSniffer()'",

--- a/package.json
+++ b/package.json
@@ -100,7 +100,7 @@
     "build:commonjs": "BABEL_ENV=cjs babel ./src --extensions \".js,.jsx,.ts,.tsx\" -d lib --copy-files",
     "build:esm": "BABEL_ENV=esm babel src -d esm --extensions \".js,.jsx,.ts,.tsx\" --copy-files",
     "build:umd": "webpack",
-    "build:pack": "npm run clean && npm run build:commonjs && npm run build:esm && npm run tsc:commonjs && npm pack --pack-destination './examples'",
+    "build:pack": "npm run clean && npm run build:commonjs && npm run build:esm && npm run tsc:commonjs && npm run tsc:esm && npm pack --pack-destination './examples'",
     "build": "npm run clean && npm run build:commonjs && npm run build:esm && npm run build:umd && npm run tsc:esm && npm run tsc:commonjs",
     "clean": "rm -rf ./lib ./esm ./umd ./examples/provenanceio-walletconnect-js-*.tgz",
     "commentSniff": "node -e 'require(\"./scripts/commentSniffer.js\").commentSniffer()'",

--- a/src/consts/urls.ts
+++ b/src/consts/urls.ts
@@ -16,6 +16,6 @@ export const APP_STORE_APPLE_FIGURE =
   'https://apps.apple.com/us/app/figure-wallet/id6444263900';
 
 // FIGURE WEB WALLET URLS
-const FIGURE_HOSTED_WALLET_URL = 'figure-wallet/connect/hosted?isPopup=true';
+export const FIGURE_HOSTED_WALLET_URL = 'figure-wallet/connect/hosted?isPopup=true';
 export const FIGURE_HOSTED_WALLET_URL_TEST = `https://test.figure.com/${FIGURE_HOSTED_WALLET_URL}`;
 export const FIGURE_HOSTED_WALLET_URL_PROD = `https://www.figure.com/${FIGURE_HOSTED_WALLET_URL}`;

--- a/src/consts/urls.ts
+++ b/src/consts/urls.ts
@@ -16,6 +16,6 @@ export const APP_STORE_APPLE_FIGURE =
   'https://apps.apple.com/us/app/figure-wallet/id6444263900';
 
 // FIGURE WEB WALLET URLS
-export const FIGURE_HOSTED_WALLET_URL = 'figure-wallet/connect/hosted?isPopup=true';
-export const FIGURE_HOSTED_WALLET_URL_TEST = `https://test.figure.com/${FIGURE_HOSTED_WALLET_URL}`;
-export const FIGURE_HOSTED_WALLET_URL_PROD = `https://www.figure.com/${FIGURE_HOSTED_WALLET_URL}`;
+const FIGURE_HOSTED_WALLET_URL_PATH = 'figure-wallet/connect/hosted?isPopup=true';
+export const FIGURE_HOSTED_WALLET_URL_TEST = `https://test.figure.com/${FIGURE_HOSTED_WALLET_URL_PATH}`;
+export const FIGURE_HOSTED_WALLET_URL_PROD = `https://www.figure.com/${FIGURE_HOSTED_WALLET_URL_PATH}`;

--- a/src/consts/walletList/hosted.ts
+++ b/src/consts/walletList/hosted.ts
@@ -1,6 +1,5 @@
 import { Wallet, WalletEventValue } from '../../types';
 import {
-  FIGURE_HOSTED_WALLET_URL,
   FIGURE_HOSTED_WALLET_URL_PROD,
   FIGURE_HOSTED_WALLET_URL_TEST,
 } from '../urls';
@@ -49,26 +48,20 @@ export const FIGURE_HOSTED_TEST = {
   eventAction: ({ uri, address, event, redirectUrl }) => {
     // If we have an event, make sure it's not an "ignored" event
     if (event && !FIGURE_HOSTED_IGNORED_EVENTS.includes(event)) {
-      // Build a full set of urlSearchParams to append to the url
-      const searchParams = new URLSearchParams();
-      if (uri) searchParams.append('wc', uri);
-      if (address) searchParams.append('address', address);
-      if (event) searchParams.append('event', event);
-      if (redirectUrl) searchParams.append('redirectUrl', redirectUrl);
-      const searchParamsString = searchParams.toString();
       const overrideUrl = localStorage.getItem(
         'FIGURE_HOSTED_WALLET_URL_TEST_OVERRIDE'
       );
-      const baseUrl = overrideUrl
-        ? `${overrideUrl}/${FIGURE_HOSTED_WALLET_URL}`
-        : FIGURE_HOSTED_WALLET_URL_TEST;
-      const url = `${baseUrl}${searchParamsString ? `&${searchParamsString}` : ''}`;
+      const windowUrl = new URL(overrideUrl ?? `${FIGURE_HOSTED_WALLET_URL_TEST}`);
+      if (uri) windowUrl.searchParams.append('wc', uri);
+      if (address) windowUrl.searchParams.append('address', address);
+      if (event) windowUrl.searchParams.append('event', event);
+      if (redirectUrl) windowUrl.searchParams.append('redirectUrl', redirectUrl);
       const width = 600;
       const height = window.outerHeight < 750 ? window.outerHeight : 550;
       const top = window.outerHeight / 2 + window.screenY - height / 2;
       const left = window.outerWidth / 2 + window.screenX - width / 2;
       const windowOptions = `popup=1 height=${height} width=${width} top=${top} left=${left} resizable=1, scrollbars=1, fullscreen=0, toolbar=0, menubar=0, status=1`;
-      window.open(url, 'figure-wallet-hosted-test', windowOptions);
+      window.open(windowUrl.toString(), 'figure-wallet-hosted-test', windowOptions);
     }
   },
 } as Wallet;

--- a/src/consts/walletList/hosted.ts
+++ b/src/consts/walletList/hosted.ts
@@ -1,9 +1,10 @@
 import { Wallet, WalletEventValue } from '../../types';
-import { WALLET_APP_IDS } from '../walletAppIds';
 import {
-  FIGURE_HOSTED_WALLET_URL_TEST,
+  FIGURE_HOSTED_WALLET_URL,
   FIGURE_HOSTED_WALLET_URL_PROD,
+  FIGURE_HOSTED_WALLET_URL_TEST,
 } from '../urls';
+import { WALLET_APP_IDS } from '../walletAppIds';
 
 const FIGURE_HOSTED_IGNORED_EVENTS: WalletEventValue[] = [
   'walletconnect_connect',
@@ -55,9 +56,13 @@ export const FIGURE_HOSTED_TEST = {
       if (event) searchParams.append('event', event);
       if (redirectUrl) searchParams.append('redirectUrl', redirectUrl);
       const searchParamsString = searchParams.toString();
-      const url = `${FIGURE_HOSTED_WALLET_URL_TEST}${
-        searchParamsString ? `&${searchParamsString}` : ''
-      }`;
+      const overrideUrl = localStorage.getItem(
+        'FIGURE_HOSTED_WALLET_URL_TEST_OVERRIDE'
+      );
+      const baseUrl = overrideUrl
+        ? `${overrideUrl}/${FIGURE_HOSTED_WALLET_URL}`
+        : FIGURE_HOSTED_WALLET_URL_TEST;
+      const url = `${baseUrl}${searchParamsString ? `&${searchParamsString}` : ''}`;
       const width = 600;
       const height = window.outerHeight < 750 ? window.outerHeight : 550;
       const top = window.outerHeight / 2 + window.screenY - height / 2;


### PR DESCRIPTION
## Description

This allows for a localStorage key to be set (`FIGURE_HOSTED_WALLET_URL_TEST_OVERRIDE`) that will override the base URL for the Figure Hosted Wallet (Test) wallet type. This should make local testing of Figure Hosted Wallet more convenient and should allow for future use in ephemeral deployments.

Also, ESM builds were not part of the `build:pack` npm script but were used by the demo site in local development.