### PR TITLE
Connection Duration Updates

### DIFF
--- a/examples/example-react-vite/package-lock.json
+++ b/examples/example-react-vite/package-lock.json
@@ -1,16 +1,16 @@
 {
   "name": "example-react-vite",
-  "version": "3.0.5",
+  "version": "3.0.6",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "example-react-vite",
-      "version": "3.0.5",
+      "version": "3.0.6",
       "dependencies": {
         "@microlink/react-json-view": "1.22.2",
         "@provenanceio/wallet-utils": "2.8.0",
-        "@provenanceio/walletconnect-js": "file:../provenanceio-walletconnect-js-3.0.5.tgz",
+        "@provenanceio/walletconnect-js": "file:../provenanceio-walletconnect-js-3.0.6.tgz",
         "react": "^18.2.0",
         "react-dom": "^18.2.0",
         "react-helmet-async": "1.3.0",
@@ -1016,9 +1016,9 @@
       }
     },
     "node_modules/@provenanceio/walletconnect-js": {
-      "version": "3.0.5",
-      "resolved": "file:../provenanceio-walletconnect-js-3.0.5.tgz",
-      "integrity": "sha512-yAx0x1zambMOgbsUOpEU/weNNgfoGJdEW7TmYUlJkewIV6t0M8q47vkDeLXJkCiJ/14sAF2xEcn+myEGmV47xw==",
+      "version": "3.0.6",
+      "resolved": "file:../provenanceio-walletconnect-js-3.0.6.tgz",
+      "integrity": "sha512-4qDt4ZLc2zCCE1m0rzz6BOiJJHNeZINsDuZWT33t/PhPGXXwGYN7umiWinmnN8+s6DTHvtcSZarv30tgsqzbaw==",
       "license": "Apache-2.0",
       "dependencies": {
         "@babel/runtime": "7.19.0",
@@ -7237,8 +7237,8 @@
       }
     },
     "@provenanceio/walletconnect-js": {
-      "version": "file:../provenanceio-walletconnect-js-3.0.5.tgz",
-      "integrity": "sha512-yAx0x1zambMOgbsUOpEU/weNNgfoGJdEW7TmYUlJkewIV6t0M8q47vkDeLXJkCiJ/14sAF2xEcn+myEGmV47xw==",
+      "version": "file:../provenanceio-walletconnect-js-3.0.6.tgz",
+      "integrity": "sha512-4qDt4ZLc2zCCE1m0rzz6BOiJJHNeZINsDuZWT33t/PhPGXXwGYN7umiWinmnN8+s6DTHvtcSZarv30tgsqzbaw==",
       "requires": {
         "@babel/runtime": "7.19.0",
         "@walletconnect/client": "1.8.0",

--- a/examples/example-react-vite/package.json
+++ b/examples/example-react-vite/package.json
@@ -1,7 +1,7 @@
 {
   "name": "example-react-vite",
   "private": true,
-  "version": "3.0.5",
+  "version": "3.0.6",
   "homepage": "/walletconnect-demo",
   "type": "module",
   "scripts": {
@@ -16,7 +16,7 @@
   "dependencies": {
     "@microlink/react-json-view": "1.22.2",
     "@provenanceio/wallet-utils": "2.8.0",
-    "@provenanceio/walletconnect-js": "file:../provenanceio-walletconnect-js-3.0.5.tgz",
+    "@provenanceio/walletconnect-js": "file:../provenanceio-walletconnect-js-3.0.6.tgz",
     "react": "^18.2.0",
     "react-dom": "^18.2.0",
     "react-helmet-async": "1.3.0",

--- a/examples/example-react-vite/src/Page/Connect.tsx
+++ b/examples/example-react-vite/src/Page/Connect.tsx
@@ -48,7 +48,7 @@ export const Connect: React.FC = () => {
   const [initialLoad, setInitialLoad] = useState(true);
   const [groupsAllowed, setGroupsAllowed] = useState(true);
   const [jwtExpiration, setJwtExpiration] = useState('');
-  const [sessionDuration, setSessionDuration] = useState('3600');
+  const [sessionDuration, setSessionDuration] = useState('');
   const [showAdvanced, setShowAdvanced] = useState(false);
   const [results, setResults] = useState<BroadcastEventData[typeof WINDOW_MESSAGES.CONNECTED] | BroadcastEventData[typeof WINDOW_MESSAGES.DISCONNECT] | undefined>();
   const { walletConnectService: wcs, walletConnectState } = useWalletConnect();
@@ -139,7 +139,7 @@ export const Connect: React.FC = () => {
               onChange={setSessionDuration}
               value={sessionDuration}
               label="Custom session duration in seconds (optional)"
-              placeholder="Use default (3600 seconds/1 hour)"
+              placeholder="Use default (24 hours)"
               bottomGap
             />
             <Checkbox

--- a/examples/example-react-vite/src/main.tsx
+++ b/examples/example-react-vite/src/main.tsx
@@ -7,7 +7,6 @@ import { CONNECT_URL } from 'consts';
 import { App } from './App';
 
 ReactDOM.createRoot(document.getElementById('root') as HTMLElement).render(
-  <React.StrictMode>
     <Router>
       <WalletConnectContextProvider
         connectionRedirect={
@@ -22,5 +21,4 @@ ReactDOM.createRoot(document.getElementById('root') as HTMLElement).render(
         </Theme>
       </WalletConnectContextProvider>
     </Router>
-  </React.StrictMode>
 );

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@provenanceio/walletconnect-js",
-  "version": "3.0.5",
+  "version": "3.0.6",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "@provenanceio/walletconnect-js",
-      "version": "3.0.5",
+      "version": "3.0.6",
       "license": "Apache-2.0",
       "dependencies": {
         "@babel/runtime": "7.19.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@provenanceio/walletconnect-js",
-  "version": "3.0.5",
+  "version": "3.0.6",
   "private": false,
   "sideEffects": false,
   "main": "esm/index.js",

--- a/src/consts/connectionTimeouts.ts
+++ b/src/consts/connectionTimeouts.ts
@@ -1,1 +1,1 @@
-export const CONNECTION_TIMEOUT = 1800000; // Default wcjs timeout in ms (default 30min)
+export const CONNECTION_TIMEOUT = 86400000; // Default wcjs timeout in ms (default 24Hours)

--- a/src/services/methods/connect/connect.ts
+++ b/src/services/methods/connect/connect.ts
@@ -14,6 +14,7 @@ interface Props {
     eventName: BroadcastEventName,
     eventData: BroadcastEventData[BroadcastEventName]
   ) => void;
+  duration: number;
   getState: () => WCSState;
   jwtExpiration?: number;
   noPopup?: boolean;
@@ -37,6 +38,7 @@ interface Props {
 export const connect = ({
   bridge,
   broadcast,
+  duration,
   getState,
   jwtExpiration,
   prohibitGroups,
@@ -53,6 +55,7 @@ export const connect = ({
   const newConnector = createConnector({
     bridge,
     broadcast,
+    duration,
     getState,
     jwtExpiration,
     prohibitGroups,

--- a/src/services/methods/connect/createConnector.ts
+++ b/src/services/methods/connect/createConnector.ts
@@ -26,6 +26,7 @@ interface Props {
     eventName: BroadcastEventName,
     eventData: BroadcastEventData[BroadcastEventName]
   ) => void;
+  duration: number;
   getState: () => WCSState;
   jwtExpiration?: number;
   noPopup?: boolean;
@@ -45,6 +46,7 @@ interface Props {
 export const createConnector = ({
   bridge,
   broadcast,
+  duration,
   getState,
   jwtExpiration,
   prohibitGroups,
@@ -70,7 +72,6 @@ export const createConnector = ({
           const eventData: EventData = {
             uri: uriData,
             event: 'walletconnect_init',
-            duration: state.connectionTimeout,
             redirectUrl: window.location.href,
           };
           // Trigger the event action based on the wallet
@@ -113,7 +114,10 @@ export const createConnector = ({
       const jwtExpirationParam = jwtExpiration
         ? `&jwtExpiration=${jwtExpiration}`
         : '';
-      const fullData = `${data}${requiredIndividualAddressParam}${requiredGroupAddressParam}${prohibitGroupsParam}${jwtExpirationParam}`;
+      const connectionDurationParam = duration
+        ? `&connectionDuration=${duration}`
+        : '';
+      const fullData = `${data}${requiredIndividualAddressParam}${requiredGroupAddressParam}${prohibitGroupsParam}${jwtExpirationParam}${connectionDurationParam}`;
       const qrcode = await QRCode.toDataURL(fullData);
       // Don't trigger a QRCodeModal popup if they say "noPopup" or pass a specific walletId
       updateModal({

--- a/src/services/walletConnectService.ts
+++ b/src/services/walletConnectService.ts
@@ -447,14 +447,21 @@ export class WalletConnectService {
   }: ConnectMethod = {}) => {
     // Only create a new connector when we're not already connected
     if (this.state.status !== 'connected') {
+      // Calculate duration to use (use passed in or default durations)
+      const finalDurationMS = duration
+        ? duration * 1000
+        : this.state.connectionTimeout;
+      // Convert back to seconds for wallets to use since jwtExpiration is already in seconds
+      const finalDurationS = finalDurationMS / 1000;
       // Update the duration of this connection
       this.#setState({
-        connectionTimeout: duration ? duration * 1000 : this.state.connectionTimeout,
+        connectionTimeout: finalDurationMS,
         status: 'pending',
       });
       const newConnector = connectMethod({
         bridge: bridge || this.state.bridge,
         broadcast: this.#broadcastEvent,
+        duration: finalDurationS,
         getState: this.#getState,
         jwtExpiration,
         prohibitGroups,


### PR DESCRIPTION
<!-- < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < ☺
v                               ✰  Thanks for creating a PR! ✰
v    Before submitting, please review the checkboxes.
v    If a checkbox is n/a - please still include it but add a note why
☺ > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > >  -->

## Description

<!-- Add a description of the changes that this PR introduces and the files that
are the most critical to review.
-->
- Version up
- Default connection duration to 24 hours
- Connection duration is now passed as a uri param instead of a wallet event for browser wallets (allow mobile to read duration from connect function)
closes: #XXXX

---

Before we can merge this PR, please make sure that all the following items have been
checked off. If any of the checklist items are not applicable, please leave them but
write a little note why.

- [ ] Targeted PR against correct branch
- [ ] Linked to Github issue with discussion and accepted design OR link to spec that describes this work.
- [ ] Added a relevant changelog entry to the `Unreleased` section in `CHANGELOG.md`
- [ ] Re-reviewed `Files changed` in the Github PR explorer