### PR TITLE
Quickfix: Resume connection use Attributes

### DIFF
--- a/examples/example-react-vite/package.json
+++ b/examples/example-react-vite/package.json
@@ -1,7 +1,7 @@
 {
   "name": "example-react-vite",
   "private": true,
-  "version": "3.2.0",
+  "version": "3.2.1",
   "homepage": "/walletconnect-demo",
   "type": "module",
   "scripts": {
@@ -16,7 +16,7 @@
   "dependencies": {
     "@microlink/react-json-view": "1.22.2",
     "@provenanceio/wallet-utils": "2.8.0",
-    "@provenanceio/walletconnect-js": "file:../provenanceio-walletconnect-js-3.2.0.tgz",
+    "@provenanceio/walletconnect-js": "file:../provenanceio-walletconnect-js-3.2.1.tgz",
     "react": "^18.2.0",
     "react-dom": "^18.2.0",
     "react-helmet-async": "1.3.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@provenanceio/walletconnect-js",
-  "version": "3.2.0",
+  "version": "3.2.1",
   "private": false,
   "sideEffects": false,
   "main": "esm/index.js",

--- a/src/services/methods/connect/connect.ts
+++ b/src/services/methods/connect/connect.ts
@@ -271,6 +271,7 @@ export const connect = ({
 
         const {
           address,
+          attributes,
           jwt: signedJWT,
           publicKey,
           representedGroupPolicy,
@@ -278,6 +279,7 @@ export const connect = ({
         } = getAccountInfo(accounts);
         setState({
           address,
+          attributes,
           connectionEST,
           connectionEXP,
           status: 'connected',

--- a/src/services/walletConnectService.ts
+++ b/src/services/walletConnectService.ts
@@ -64,7 +64,7 @@ const defaultState: WCSState = {
   publicKey: '',
   representedGroupPolicy: null,
   signedJWT: '',
-  version: '3.2.0',
+  version: '3.2.1',
   walletAppId: undefined,
   walletInfo: {},
 };


### PR DESCRIPTION
<!-- < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < ☺
v                               ✰  Thanks for creating a PR! ✰
v    Before submitting, please review the checkboxes.
v    If a checkbox is n/a - please still include it but add a note why
☺ > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > >  -->

## Description
- v3.2.1
- When resuming a connection (reloading page), make sure to pull saved attributes with getAccountInfo method.  This was accidentally left out.
<!-- Add a description of the changes that this PR introduces and the files that
are the most critical to review.
-->

closes: #XXXX

---

Before we can merge this PR, please make sure that all the following items have been
checked off. If any of the checklist items are not applicable, please leave them but
write a little note why.

- [ ] Targeted PR against correct branch
- [ ] Linked to Github issue with discussion and accepted design OR link to spec that describes this work.
- [ ] Added a relevant changelog entry to the `Unreleased` section in `CHANGELOG.md`
- [ ] Re-reviewed `Files changed` in the Github PR explorer