### PR TITLE
fix: prevent closing iframe on disconnect [sc-247772]

### DIFF
--- a/examples/example-react-vite/package-lock.json
+++ b/examples/example-react-vite/package-lock.json
@@ -1018,7 +1018,7 @@
     "node_modules/@provenanceio/walletconnect-js": {
       "version": "3.4.0",
       "resolved": "file:../provenanceio-walletconnect-js-3.4.0.tgz",
-      "integrity": "sha512-a84ngIivokT9q0f2+Ezs6n9NF+Q8YKtlB2tpYw+UfyxdqOGOig3Lu2+Hyoju3QHVuYdjKKJk99zzMaojmLBI9w==",
+      "integrity": "sha512-om4tsUlv9oYEQWJ0TLrU0Q+31bXOclw8YZQsLBYrpnZHY0LeOyf06BF0oElkTua0F7yIiOcLtEUaxo4bDO6SQQ==",
       "license": "Apache-2.0",
       "dependencies": {
         "@walletconnect/client": "1.8.0",
@@ -7239,7 +7239,7 @@
     },
     "@provenanceio/walletconnect-js": {
       "version": "file:../provenanceio-walletconnect-js-3.4.0.tgz",
-      "integrity": "sha512-a84ngIivokT9q0f2+Ezs6n9NF+Q8YKtlB2tpYw+UfyxdqOGOig3Lu2+Hyoju3QHVuYdjKKJk99zzMaojmLBI9w==",
+      "integrity": "sha512-om4tsUlv9oYEQWJ0TLrU0Q+31bXOclw8YZQsLBYrpnZHY0LeOyf06BF0oElkTua0F7yIiOcLtEUaxo4bDO6SQQ==",
       "requires": {
         "@walletconnect/client": "1.8.0",
         "@walletconnect/utils": "1.8.0",

--- a/examples/example-react-vite/package-lock.json
+++ b/examples/example-react-vite/package-lock.json
@@ -1018,7 +1018,7 @@
     "node_modules/@provenanceio/walletconnect-js": {
       "version": "3.4.0",
       "resolved": "file:../provenanceio-walletconnect-js-3.4.0.tgz",
-      "integrity": "sha512-om4tsUlv9oYEQWJ0TLrU0Q+31bXOclw8YZQsLBYrpnZHY0LeOyf06BF0oElkTua0F7yIiOcLtEUaxo4bDO6SQQ==",
+      "integrity": "sha512-Mp8LM1EH5GGOGv2inug7nV+vwQtVtt/ZY6vbQnOD/BoLhk43Xu+gNBOM2g71T6PmvjmMRy7olj0jQ7n11vPdDA==",
       "license": "Apache-2.0",
       "dependencies": {
         "@walletconnect/client": "1.8.0",
@@ -7239,7 +7239,7 @@
     },
     "@provenanceio/walletconnect-js": {
       "version": "file:../provenanceio-walletconnect-js-3.4.0.tgz",
-      "integrity": "sha512-om4tsUlv9oYEQWJ0TLrU0Q+31bXOclw8YZQsLBYrpnZHY0LeOyf06BF0oElkTua0F7yIiOcLtEUaxo4bDO6SQQ==",
+      "integrity": "sha512-Mp8LM1EH5GGOGv2inug7nV+vwQtVtt/ZY6vbQnOD/BoLhk43Xu+gNBOM2g71T6PmvjmMRy7olj0jQ7n11vPdDA==",
       "requires": {
         "@walletconnect/client": "1.8.0",
         "@walletconnect/utils": "1.8.0",

--- a/examples/example-react-vite/package-lock.json
+++ b/examples/example-react-vite/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "example-react-vite",
-  "version": "3.4.0",
+  "version": "3.4.1",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "example-react-vite",
-      "version": "3.4.0",
+      "version": "3.4.1",
       "dependencies": {
         "@microlink/react-json-view": "1.22.2",
         "@provenanceio/wallet-utils": "2.8.0",

--- a/examples/example-react-vite/package.json
+++ b/examples/example-react-vite/package.json
@@ -1,7 +1,7 @@
 {
   "name": "example-react-vite",
   "private": true,
-  "version": "3.4.0",
+  "version": "3.4.1",
   "homepage": "/walletconnect-demo",
   "type": "module",
   "scripts": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@provenanceio/walletconnect-js",
-  "version": "3.4.0",
+  "version": "3.4.1",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "@provenanceio/walletconnect-js",
-      "version": "3.4.0",
+      "version": "3.4.1",
       "license": "Apache-2.0",
       "dependencies": {
         "@walletconnect/client": "1.8.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@provenanceio/walletconnect-js",
-  "version": "3.4.0",
+  "version": "3.4.1",
   "private": false,
   "sideEffects": false,
   "main": "esm/index.js",

--- a/src/hooks/useHostedWalletIframe.ts
+++ b/src/hooks/useHostedWalletIframe.ts
@@ -163,10 +163,6 @@ const catchWCJSMessage = ({ detail }: CustomEvent<EventData>) => {
       createIframe(windowUrl.toString());
       break;
     }
-    case 'walletconnect_disconnect': {
-      removeIframe();
-      break;
-    }
     default:
       break;
   }

--- a/src/hooks/useHostedWalletIframe.ts
+++ b/src/hooks/useHostedWalletIframe.ts
@@ -149,7 +149,8 @@ const catchWCJSMessage = ({ detail }: CustomEvent<EventData>) => {
   // Based on the event type handle what we do
   switch (event) {
     case 'walletconnect_event':
-    case 'walletconnect_init': {
+    case 'walletconnect_init':
+    case 'walletconnect_disconnect': {
       // Only create the iframe if one doesn't already exist (prevent accidental double clicking)
       if (iframeExists()) {
         return;


### PR DESCRIPTION
**Problem**
The current Hosted Wallet iframe logic closes the iframe on a `walletconnect_disconnect` event. However this doesn't allow the Hosted Wallet app a chance to clean up state because the app is not loaded (the iframe is removed from the DOM).

**Solution**
Don't remove the iframe on `walletconnect_disconnect`, instead allow the Hosted Wallet app to handle clearing localStorage and then it will send a message to wcjs to close the iframe when it's ready. This should reduce the chance for weird or corrupt state.