### PR TITLE
feat: Make iframe the default experience for Hosted Wallet

### DIFF
--- a/examples/example-react-vite/package-lock.json
+++ b/examples/example-react-vite/package-lock.json
@@ -1,16 +1,16 @@
 {
   "name": "example-react-vite",
-  "version": "3.4.1",
+  "version": "3.5.0",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "example-react-vite",
-      "version": "3.4.1",
+      "version": "3.5.0",
       "dependencies": {
         "@microlink/react-json-view": "1.22.2",
         "@provenanceio/wallet-utils": "2.8.0",
-        "@provenanceio/walletconnect-js": "file:../provenanceio-walletconnect-js-3.4.0.tgz",
+        "@provenanceio/walletconnect-js": "file:../provenanceio-walletconnect-js-3.5.0.tgz",
         "react": "^18.2.0",
         "react-dom": "^18.2.0",
         "react-helmet-async": "1.3.0",
@@ -1016,9 +1016,9 @@
       }
     },
     "node_modules/@provenanceio/walletconnect-js": {
-      "version": "3.4.0",
-      "resolved": "file:../provenanceio-walletconnect-js-3.4.0.tgz",
-      "integrity": "sha512-Mp8LM1EH5GGOGv2inug7nV+vwQtVtt/ZY6vbQnOD/BoLhk43Xu+gNBOM2g71T6PmvjmMRy7olj0jQ7n11vPdDA==",
+      "version": "3.5.0",
+      "resolved": "file:../provenanceio-walletconnect-js-3.5.0.tgz",
+      "integrity": "sha512-oISqG4+pS8Peo1CgAGgNi3QbyyvsIvDyb+efnsQpmNYGydPIARFdjxtsn6WrOu2EkbN4C72e+I6WX9uBcClimQ==",
       "license": "Apache-2.0",
       "dependencies": {
         "@walletconnect/client": "1.8.0",
@@ -7238,8 +7238,8 @@
       }
     },
     "@provenanceio/walletconnect-js": {
-      "version": "file:../provenanceio-walletconnect-js-3.4.0.tgz",
-      "integrity": "sha512-Mp8LM1EH5GGOGv2inug7nV+vwQtVtt/ZY6vbQnOD/BoLhk43Xu+gNBOM2g71T6PmvjmMRy7olj0jQ7n11vPdDA==",
+      "version": "file:../provenanceio-walletconnect-js-3.5.0.tgz",
+      "integrity": "sha512-oISqG4+pS8Peo1CgAGgNi3QbyyvsIvDyb+efnsQpmNYGydPIARFdjxtsn6WrOu2EkbN4C72e+I6WX9uBcClimQ==",
       "requires": {
         "@walletconnect/client": "1.8.0",
         "@walletconnect/utils": "1.8.0",

--- a/examples/example-react-vite/package.json
+++ b/examples/example-react-vite/package.json
@@ -1,7 +1,7 @@
 {
   "name": "example-react-vite",
   "private": true,
-  "version": "3.4.1",
+  "version": "3.5.0",
   "homepage": "/walletconnect-demo",
   "type": "module",
   "scripts": {
@@ -16,7 +16,7 @@
   "dependencies": {
     "@microlink/react-json-view": "1.22.2",
     "@provenanceio/wallet-utils": "2.8.0",
-    "@provenanceio/walletconnect-js": "file:../provenanceio-walletconnect-js-3.4.0.tgz",
+    "@provenanceio/walletconnect-js": "file:../provenanceio-walletconnect-js-3.5.0.tgz",
     "react": "^18.2.0",
     "react-dom": "^18.2.0",
     "react-helmet-async": "1.3.0",

--- a/examples/example-react-vite/src/Page/Connect.tsx
+++ b/examples/example-react-vite/src/Page/Connect.tsx
@@ -205,7 +205,7 @@ export const Connect: React.FC = () => {
         )}
         <QRCodeModalStyled
           walletConnectService={wcs}
-          devWallets={['figure_hosted_test', 'figure_mobile_test', 'figure_hosted_test_iframe']}
+          devWallets={['figure_hosted_test', 'figure_mobile_test']}
         />
       </Card>
     );
@@ -218,7 +218,7 @@ export const Connect: React.FC = () => {
       Connection is currently pending.
       <QRCodeModalStyled
         walletConnectService={wcs}
-        devWallets={['figure_hosted_test', 'figure_mobile_test', 'figure_hosted_test_iframe']}
+        devWallets={['figure_hosted_test', 'figure_mobile_test']}
       />
     </Card>
   );

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@provenanceio/walletconnect-js",
-  "version": "3.4.1",
+  "version": "3.5.0",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "@provenanceio/walletconnect-js",
-      "version": "3.4.1",
+      "version": "3.5.0",
       "license": "Apache-2.0",
       "dependencies": {
         "@walletconnect/client": "1.8.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@provenanceio/walletconnect-js",
-  "version": "3.4.1",
+  "version": "3.5.0",
   "private": false,
   "sideEffects": false,
   "main": "esm/index.js",

--- a/src/consts/urls.ts
+++ b/src/consts/urls.ts
@@ -16,6 +16,6 @@ export const APP_STORE_APPLE_FIGURE =
   'https://apps.apple.com/us/app/figure-wallet/id6444263900';
 
 // FIGURE WEB WALLET URLS
-const FIGURE_HOSTED_WALLET_URL_PATH = 'figure-wallet/connect/hosted?isPopup=true';
+const FIGURE_HOSTED_WALLET_URL_PATH = 'figure-wallet/connect';
 export const FIGURE_HOSTED_WALLET_URL_TEST = `https://test.figure.com/${FIGURE_HOSTED_WALLET_URL_PATH}`;
 export const FIGURE_HOSTED_WALLET_URL_PROD = `https://www.figure.com/${FIGURE_HOSTED_WALLET_URL_PATH}`;

--- a/src/consts/walletAppIds.ts
+++ b/src/consts/walletAppIds.ts
@@ -4,5 +4,4 @@ export const WALLET_APP_IDS = {
   FIGURE_MOBILE_TEST: 'figure_mobile_test',
   FIGURE_HOSTED: 'figure_hosted',
   FIGURE_HOSTED_TEST: 'figure_hosted_test',
-  FIGURE_HOSTED_TEST_IFRAME: 'figure_hosted_test_iframe',
 } as const;

--- a/src/consts/walletList/hosted.ts
+++ b/src/consts/walletList/hosted.ts
@@ -1,9 +1,6 @@
 import { HOSTED_IFRAME_EVENT_TYPE } from '../../consts';
 import { Wallet, WalletEventValue } from '../../types';
-import {
-  FIGURE_HOSTED_WALLET_URL_PROD,
-  FIGURE_HOSTED_WALLET_URL_TEST,
-} from '../urls';
+import { FIGURE_HOSTED_WALLET_URL_PROD } from '../urls';
 import { WALLET_APP_IDS } from '../walletAppIds';
 
 const FIGURE_HOSTED_IGNORED_EVENTS: WalletEventValue[] = [
@@ -46,39 +43,14 @@ export const FIGURE_HOSTED_TEST = {
   type: ['hosted', 'mobile'],
   title: 'Figure Account (Test)',
   icon: 'figure',
-  eventAction: ({ uri, address, event, redirectUrl }) => {
-    // If we have an event, make sure it's not an "ignored" event
-    if (event && !FIGURE_HOSTED_IGNORED_EVENTS.includes(event)) {
-      const overrideUrl = localStorage.getItem(
-        'FIGURE_HOSTED_WALLET_URL_TEST_OVERRIDE'
-      );
-      const windowUrl = new URL(overrideUrl ?? `${FIGURE_HOSTED_WALLET_URL_TEST}`);
-      if (uri) windowUrl.searchParams.append('wc', uri);
-      if (address) windowUrl.searchParams.append('address', address);
-      if (event) windowUrl.searchParams.append('event', event);
-      if (redirectUrl) windowUrl.searchParams.append('redirectUrl', redirectUrl);
-      const width = 600;
-      const height = window.outerHeight < 750 ? window.outerHeight : 550;
-      const top = window.outerHeight / 2 + window.screenY - height / 2;
-      const left = window.outerWidth / 2 + window.screenX - width / 2;
-      const windowOptions = `popup=1 height=${height} width=${width} top=${top} left=${left} resizable=1, scrollbars=1, fullscreen=0, toolbar=0, menubar=0, status=1`;
-      window.open(windowUrl.toString(), 'figure-wallet-hosted-test', windowOptions);
-    }
-  },
-} as Wallet;
-
-export const FIGURE_HOSTED_TEST_IFRAME = {
-  dev: true,
-  id: WALLET_APP_IDS.FIGURE_HOSTED_TEST_IFRAME,
-  type: ['hosted', 'mobile'],
-  title: 'Figure Account (iframe)',
-  icon: 'figure',
   eventAction: (eventData) => {
     const { event } = eventData;
     // If we have an event, make sure it's not an "ignored" event
     if (event && !FIGURE_HOSTED_IGNORED_EVENTS.includes(event)) {
       window.document.dispatchEvent(
-        new CustomEvent(HOSTED_IFRAME_EVENT_TYPE, { detail: eventData })
+        new CustomEvent(HOSTED_IFRAME_EVENT_TYPE, {
+          detail: { ...eventData, walletId: WALLET_APP_IDS.FIGURE_HOSTED_TEST },
+        })
       );
     }
   },

--- a/src/consts/walletList/index.ts
+++ b/src/consts/walletList/index.ts
@@ -1,9 +1,5 @@
 import { FIGURE_EXTENSION } from './extension';
-import {
-  FIGURE_HOSTED,
-  FIGURE_HOSTED_TEST,
-  FIGURE_HOSTED_TEST_IFRAME,
-} from './hosted';
+import { FIGURE_HOSTED, FIGURE_HOSTED_TEST } from './hosted';
 import { FIGURE_MOBILE, FIGURE_MOBILE_TEST } from './mobile';
 
 export const WALLET_LIST = [
@@ -12,5 +8,4 @@ export const WALLET_LIST = [
   FIGURE_MOBILE_TEST,
   FIGURE_HOSTED,
   FIGURE_HOSTED_TEST,
-  FIGURE_HOSTED_TEST_IFRAME,
 ];

--- a/src/types/WalletList.ts
+++ b/src/types/WalletList.ts
@@ -7,7 +7,6 @@ export type WalletId =
   | 'figure_extension'
   | 'figure_hosted'
   | 'figure_hosted_test'
-  | 'figure_hosted_test_iframe'
   | 'figure_mobile'
   | 'figure_mobile_test';
 export type WalletIcons = 'provenance' | 'figure';
@@ -15,6 +14,7 @@ export type WalletIcons = 'provenance' | 'figure';
 export type WalletEventData = any; // eslint-disable-line @typescript-eslint/no-explicit-any
 
 export interface EventData {
+  walletId?: WalletId;
   event?: WalletEventValue;
   uri?: string;
   address?: string;


### PR DESCRIPTION
This PR removes the additional test wallet created for iframe for Hosted Wallet and makes the Figure Account (Test) wallet use the iframe by default. The production Figure Account still uses the popup as before (change to that will come after a day or two of testing in test env).

In order to handle selecting the right URL for the popup and for messaging with the iframe, I added the walletId to the event data (as an optional field). This shouldn't have any effect or impact on any other wallets but will allow the hosted iframe hook to know whether to use the test or prod URL for the iframe.

This bumps the version to v3.5.0