### PR TITLE
bug(wcjs): Fix timer issues

### DIFF
--- a/examples/example-react-vite/package-lock.json
+++ b/examples/example-react-vite/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "example-react-vite",
-  "version": "3.9.0",
+  "version": "3.9.1",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "example-react-vite",
-      "version": "3.9.0",
+      "version": "3.9.1",
       "hasInstallScript": true,
       "dependencies": {
         "@microlink/react-json-view": "1.22.2",

--- a/examples/example-react-vite/package-lock.json
+++ b/examples/example-react-vite/package-lock.json
@@ -11,7 +11,7 @@
       "dependencies": {
         "@microlink/react-json-view": "1.22.2",
         "@provenanceio/wallet-utils": "2.8.0",
-        "@provenanceio/walletconnect-js": "file:../provenanceio-walletconnect-js-3.9.0.tgz",
+        "@provenanceio/walletconnect-js": "file:../provenanceio-walletconnect-js-3.9.1.tgz",
         "react": "^18.2.0",
         "react-dom": "^18.2.0",
         "react-helmet-async": "1.3.0",
@@ -1017,9 +1017,9 @@
       }
     },
     "node_modules/@provenanceio/walletconnect-js": {
-      "version": "3.9.0",
-      "resolved": "file:../provenanceio-walletconnect-js-3.9.0.tgz",
-      "integrity": "sha512-DSq9hkZ6zk3Q22EQBG0Dkvt66oQLv1sPZ1MipvIsEeJ0/cqWfgvk3G5AjR6tBwYkHA7iZNSG/DcgF2NKPB7LuQ==",
+      "version": "3.9.1",
+      "resolved": "file:../provenanceio-walletconnect-js-3.9.1.tgz",
+      "integrity": "sha512-fd91Op/T17OHUxArmgw4wEBJJvdxS34SXKjtSENFEivuVTiY1u2/A32WxocddgPU56ssfWMVioWENprmXkllCQ==",
       "license": "Apache-2.0",
       "dependencies": {
         "@walletconnect/client": "1.8.0",
@@ -7239,8 +7239,8 @@
       }
     },
     "@provenanceio/walletconnect-js": {
-      "version": "file:../provenanceio-walletconnect-js-3.9.0.tgz",
-      "integrity": "sha512-DSq9hkZ6zk3Q22EQBG0Dkvt66oQLv1sPZ1MipvIsEeJ0/cqWfgvk3G5AjR6tBwYkHA7iZNSG/DcgF2NKPB7LuQ==",
+      "version": "file:../provenanceio-walletconnect-js-3.9.1.tgz",
+      "integrity": "sha512-fd91Op/T17OHUxArmgw4wEBJJvdxS34SXKjtSENFEivuVTiY1u2/A32WxocddgPU56ssfWMVioWENprmXkllCQ==",
       "requires": {
         "@walletconnect/client": "1.8.0",
         "@walletconnect/utils": "1.8.0",

--- a/examples/example-react-vite/package.json
+++ b/examples/example-react-vite/package.json
@@ -16,7 +16,7 @@
   "dependencies": {
     "@microlink/react-json-view": "1.22.2",
     "@provenanceio/wallet-utils": "2.8.0",
-    "@provenanceio/walletconnect-js": "file:../provenanceio-walletconnect-js-3.9.0.tgz",
+    "@provenanceio/walletconnect-js": "file:../provenanceio-walletconnect-js-3.9.1.tgz",
     "react": "^18.2.0",
     "react-dom": "^18.2.0",
     "react-helmet-async": "1.3.0",

--- a/examples/example-react-vite/package.json
+++ b/examples/example-react-vite/package.json
@@ -1,7 +1,7 @@
 {
   "name": "example-react-vite",
   "private": true,
-  "version": "3.9.0",
+  "version": "3.9.1",
   "homepage": "/walletconnect-demo",
   "type": "module",
   "scripts": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@provenanceio/walletconnect-js",
-  "version": "3.9.0",
+  "version": "3.9.1",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "@provenanceio/walletconnect-js",
-      "version": "3.9.0",
+      "version": "3.9.1",
       "license": "Apache-2.0",
       "dependencies": {
         "@walletconnect/client": "1.8.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@provenanceio/walletconnect-js",
-  "version": "3.9.0",
+  "version": "3.9.1",
   "private": false,
   "sideEffects": false,
   "main": "esm/index.js",

--- a/src/services/methods/connect/connect.ts
+++ b/src/services/methods/connect/connect.ts
@@ -37,7 +37,6 @@ interface Props {
   requiredIndividualAddress?: string;
   resetState: () => void;
   setState: WCSSetState;
-  startConnectionTimer: () => void;
   state: WCSState;
   updateModal: (
     newModalData: Partial<ModalData> & { walletAppId?: WalletId }
@@ -57,7 +56,6 @@ export const connect = ({
   requiredIndividualAddress,
   resetState,
   setState,
-  startConnectionTimer,
   state,
   updateModal,
   walletAppId: connectionWalletAppId,
@@ -185,7 +183,6 @@ export const connect = ({
     // - Calculate new connection EST/EXP
     // - Save accounts (account data), peer, connection EST/EXP, and connected value to walletConnectService
     // - Broadcast "connect" event (let the dApp know)
-    // - Start the "connection timer" to auto-disconnect wcjs when session is expired
     // - Trigger wallet event for "connect" (let the wallet know)
     newConnector.on(CONNECTOR_EVENTS.connect, (error, payload: ConnectData) => {
       if (error) throw error;
@@ -221,7 +218,6 @@ export const connect = ({
           connectionType: CONNECTION_TYPES.new_session,
         },
       });
-      startConnectionTimer();
       const { walletAppId } = getState();
       if (walletAppId) sendWalletEvent(walletAppId, WALLET_APP_EVENTS.CONNECT);
     });
@@ -252,7 +248,6 @@ export const connect = ({
     //    - Note: connectionEXP must exist to "update" the session
     // - Save newConnector to walletConnectService state (data inside likely changed due to this event)
     // - Broadcast "session_update" event (let the dApp know)
-    // - Start the "connection timer" to auto-disconnect wcjs when session is expired
     // - Trigger wallet event for "session_update" (let the wallet know)
     const resumeResumeEvent = () => {
       if (newConnector) {
@@ -274,7 +269,6 @@ export const connect = ({
               connectionType: CONNECTION_TYPES.existing_session,
             },
           });
-          startConnectionTimer();
           const { walletAppId } = getState();
           if (walletAppId) {
             sendWalletEvent(walletAppId, WALLET_APP_EVENTS.SESSION_UPDATE);
@@ -293,7 +287,6 @@ export const connect = ({
     // ------------------------
     // - Save accounts (account data), peer, connection EST/EXP, and connected value to walletConnectService
     // - Broadcast "session_update" event (let the dApp know)
-    // - Start the "connection timer" to auto-disconnect wcjs when session is expired
     // - Trigger wallet event for "session_update" (let the wallet know)
     newConnector.on(
       CONNECTOR_EVENTS.wc_sessionUpdate,
@@ -337,7 +330,6 @@ export const connect = ({
             connectionType: CONNECTION_TYPES.existing_session,
           },
         });
-        startConnectionTimer();
         const { walletAppId } = getState();
         if (walletAppId)
           sendWalletEvent(walletAppId, WALLET_APP_EVENTS.SESSION_UPDATE);

--- a/src/services/walletConnectService.ts
+++ b/src/services/walletConnectService.ts
@@ -84,6 +84,7 @@ export class WalletConnectService {
   state: WCSState = defaultState;
 
   constructor() {
+    this.#startConnectionTimer();
     this.#buildInitialState();
     // Add a way to log the current walletconnect-js state from console on any dApp
     window.wcjs = window.wcjs || {
@@ -199,32 +200,18 @@ export class WalletConnectService {
 
   // Control auto-disconnect / timeout
   #startConnectionTimer = () => {
-    // Can't start a timer if one is already running (make sure we have EXP and EST too)
-    if (
-      !this.#connectionTimer &&
-      this.state.connectionEXP &&
-      this.state.connectionEST
-    ) {
-      // Get the time until expiration (typically this.state.connectionTimeout, but might not be if session restored from refresh)
-      const connectionTimeout = this.state.connectionEXP - Date.now();
-      // Create a new timer
-      const newConnectionTimer = window.setTimeout(() => {
-        // When this timer expires, kill the session
-        this.disconnect();
-      }, connectionTimeout);
-      // Save this timer (so it can be deleted on a reset)
-      this.#connectionTimer = newConnectionTimer;
-    }
-  };
-
-  // Stop the current running connection timer
-  #clearConnectionTimer = () => {
-    if (this.#connectionTimer) {
-      // Stop timer
-      window.clearTimeout(this.#connectionTimer);
-      // Reset timer value to 0
-      this.#connectionTimer = 0;
-    }
+    // Every 1000ms check to see if connection is expired
+    setInterval(() => {
+      const nowMs = Date.now();
+      if (
+        this.state.connected &&
+        this.state.connectionEXP &&
+        nowMs >= this.state.connectionEXP
+      ) {
+        // We're connected, with a valid connectionEXP, and the current time is past the exp, so disconnect.
+        this.disconnect('Connection Expired');
+      }
+    }, 1000);
   };
 
   // Pull latest state values on demand (prevent stale state in callback events)
@@ -264,7 +251,7 @@ export class WalletConnectService {
 
   // Change the class state
   #setState: WCSSetState = (updatedState, updateLocalStorage = true) => {
-    // If the updatedState passes a connector value we want to use it but save it separatly from the public state
+    // If the updatedState passes a connector value we want to use it but save it separately from the public state
     const { connector, ...filteredUpdatedState } = updatedState;
     let finalUpdatedState = { ...filteredUpdatedState };
     // If we get a new "connector" passed in, pull various data keys out
@@ -435,14 +422,10 @@ export class WalletConnectService {
     const newConnectionTimeout = connectionTimeout
       ? connectionTimeout * 1000
       : this.state.connectionTimeout;
-    // Kill the last timer (if it exists)
-    this.#clearConnectionTimer();
     // Build a new connectionEXP (Iat + connectionTimeout)
     const connectionEXP = newConnectionTimeout + Date.now();
     // Save these new values (needed for session restore functionality/page refresh)
     this.#setState({ connectionTimeout: newConnectionTimeout, connectionEXP });
-    // Start a new timer
-    this.#startConnectionTimer();
     // Send connected wallet custom event with the new connection details
     if (this.state.walletAppId) {
       sendWalletEvent(
@@ -500,7 +483,6 @@ export class WalletConnectService {
         requiredIndividualAddress: individualAddress,
         resetState: this.#resetState,
         setState: this.#setState,
-        startConnectionTimer: this.#startConnectionTimer,
         state: this.state,
         updateModal: this.updateModal,
         walletAppId,
@@ -520,8 +502,6 @@ export class WalletConnectService {
    * @param message (optional) Custom disconnect message to send back to dApp
    * */
   disconnect = async (message?: string) => {
-    // Clear out the existing connection timer
-    this.#clearConnectionTimer();
     // Only do this if we have a connector and the connector is connected
     // Note: If we don't check for connected can generate an "invalid topic" error
     if (this.#connector && this.#connector.connected)

--- a/src/services/walletConnectService.ts
+++ b/src/services/walletConnectService.ts
@@ -71,8 +71,6 @@ const defaultState: WCSState = {
 };
 
 export class WalletConnectService {
-  #connectionTimer = 0;
-
   #connector?: WalletConnectClientType;
 
   #eventEmitter = new events.EventEmitter();


### PR DESCRIPTION
<!-- < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < ☺
v                               ✰  Thanks for creating a PR! ✰
v    Before submitting, please review the checkboxes.
v    If a checkbox is n/a - please still include it but add a note why
☺ > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > >  -->

## Description
Using a setTimeout for the duration of the connection is very inaccurate when used outside a web worker.  Instead, create a single timer that runs every 1000ms and checks for a connection and exp and will auto disconnect as needed.  Significantly less code and we won't have time drift issues when the tab is no longer active.
<!-- Add a description of the changes that this PR introduces and the files that
are the most critical to review.
-->

closes: #XXXX

---

Before we can merge this PR, please make sure that all the following items have been
checked off. If any of the checklist items are not applicable, please leave them but
write a little note why.

- [ ] Targeted PR against correct branch
- [ ] Linked to Github issue with discussion and accepted design OR link to spec that describes this work.
- [ ] Added a relevant changelog entry to the `Unreleased` section in `CHANGELOG.md`
- [ ] Re-reviewed `Files changed` in the Github PR explorer